### PR TITLE
add write token support

### DIFF
--- a/Private/Select-ClientToken.ps1
+++ b/Private/Select-ClientToken.ps1
@@ -20,7 +20,7 @@ function Select-ClientToken {
     }
     else {
         if ($Script:CIF3.ReadToken -and $RequestType -eq "Read") {
-            # use the read token only if token is not configured
+            # use the read token if configured
             Write-Verbose "Selecting read_token"
             return $Script:CIF3.ReadToken
         }

--- a/Private/Select-ClientToken.ps1
+++ b/Private/Select-ClientToken.ps1
@@ -1,0 +1,37 @@
+function Select-ClientToken {
+    # helper function that selects the appropriate token for the client action
+    # read options should use 'read_token' if available
+    # write options should use 'write_token' if available
+    # otherwise default to 'token'
+    param (
+        [Parameter(Mandatory = $true)]  
+        [string]$Token,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('Read', 'Write')]
+        [string]$RequestType = "Read"
+    )
+
+    if ($Token -ne $Script:CIF3.Token) {
+        # $Token defaults to $Script:CIF3.Token in the public functions
+        # use explicitly provided token from the public function if provided
+        Write-Verbose "Selecting explicitly passed token"
+        return $Token
+    }
+    else {
+        if ($Script:CIF3.ReadToken -and $RequestType -eq "Read") {
+            # use the read token only if token is not configured
+            Write-Verbose "Selecting read_token"
+            return $Script:CIF3.ReadToken
+        }
+        elseif ($Script:CIF3.WriteToken -and $RequestType -eq "Write") {
+            # use the write token if configured
+            Write-Verbose "Selecting write_token"
+            return $Script:CIF3.WriteToken
+        }
+        else {
+            Write-Verbose "Selecting token"
+            return $Script:CIF3.Token
+        }
+    }
+}

--- a/Public/Add-CIF3Indicator.ps1
+++ b/Public/Add-CIF3Indicator.ps1
@@ -77,11 +77,8 @@ function Add-CIF3Indicator {
 
     begin {
         $Uri += '/indicators'
-        
-        # use write token if available and a token is not explicitly passed
-        if ($Token -eq $Script:CIF3.Token -and $null -ne $Script:CIF3.WriteToken) {
-            $Token = $Script:CIF3.WriteToken
-        }
+
+        $Token = Select-ClientToken -Token $Token -RequestType 'Write'
 
         $Body = @{ }
 

--- a/Public/Add-CIF3Indicator.ps1
+++ b/Public/Add-CIF3Indicator.ps1
@@ -78,6 +78,11 @@ function Add-CIF3Indicator {
     begin {
         $Uri += '/indicators'
         
+        # use write token if available and a token is not explicitly passed
+        if ($Token -eq $Script:CIF3.Token -and $null -ne $Script:CIF3.WriteToken) {
+            $Token = $Script:CIF3.WriteToken
+        }
+
         $Body = @{ }
 
         switch($PSBoundParameters.Keys) {

--- a/Public/Get-CIF3Config.ps1
+++ b/Public/Get-CIF3Config.ps1
@@ -52,6 +52,7 @@ function Get-CIF3Config {
             @{l = 'Uri'; e = { Decrypt $_.client.remote } },
             @{l = 'Token'; e = { Decrypt $_.client.token } },
             @{l = 'ReadToken'; e = { Decrypt $_.client.read_token } },
+            @{l = 'WriteToken'; e = { Decrypt $_.client.write_token } },
             @{l = 'ForceVerbose'; e = { $_.client.force_verbose } },
             @{l = 'NoVerifySsl'; e = { $_.client.no_verify_ssl } }
 
@@ -62,6 +63,10 @@ function Get-CIF3Config {
         # backfill ReadToken prop if it's empty
         if ($null -ne $TempObj.Token -and $null -eq $TempObj.ReadToken) {
             $TempObj.ReadToken = $TempObj.Token
+        }
+        # backfill WriteToken prop if it's empty
+        if ($null -ne $TempObj.Token -and $null -eq $TempObj.WriteToken) {
+            $TempObj.WriteToken = $TempObj.Token
         }
 
         # Nice oneliner to convert PSCustomObject to Hashtable: https://stackoverflow.com/questions/3740128/pscustomobject-to-hashtable

--- a/Public/Get-CIF3Config.ps1
+++ b/Public/Get-CIF3Config.ps1
@@ -70,10 +70,6 @@ function Get-CIF3Config {
         if ($null -ne $TempObj.Token -and $null -eq $TempObj.ReadToken) {
             $TempObj.ReadToken = $TempObj.Token
         }
-        # backfill WriteToken prop if it's empty
-        if ($null -ne $TempObj.Token -and $null -eq $TempObj.WriteToken) {
-            $TempObj.WriteToken = $TempObj.Token
-        }
 
         # Nice oneliner to convert PSCustomObject to Hashtable: https://stackoverflow.com/questions/3740128/pscustomobject-to-hashtable
         $TempObj.PSObject.Properties | ForEach-Object -Begin { $h = @{ } } -Process { $h."$($_.Name)" = $_.Value } -End { $h } 

--- a/Public/Get-CIF3Feed.ps1
+++ b/Public/Get-CIF3Feed.ps1
@@ -92,6 +92,8 @@ function Get-CIF3Feed {
     begin {
         $Uri += '/feed'
         
+        $Token = Select-ClientToken -Token $Token -RequestType 'Read'
+
         $Body = @{ }
 
         # PSBoundParameters contains only params where value was supplied by caller, ie, does not contain

--- a/Public/Get-CIF3Indicator.ps1
+++ b/Public/Get-CIF3Indicator.ps1
@@ -91,6 +91,8 @@ function Get-CIF3Indicator {
     begin {
         $Uri += '/indicators'
         
+        $Token = Select-ClientToken -Token $Token -RequestType 'Read'
+        
         $Body = @{ }
 
         # PSBoundParameters contains only params where value was supplied by caller, ie, does not contain

--- a/Public/Set-CIF3Config.ps1
+++ b/Public/Set-CIF3Config.ps1
@@ -17,6 +17,9 @@ function Set-CIF3Config {
     .PARAMETER ReadToken
         Specify a read Token to use (used if you have separate read/write tokens)
 
+    .PARAMETER WriteToken
+        Specify a write Token to use (used if you have separate read/write tokens)
+    
     .PARAMETER EncryptToken
         If set to true, serializes token to disk via DPAPI (Windows only)
 
@@ -53,6 +56,9 @@ function Set-CIF3Config {
         [string]$ReadToken,
 
         [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true)]
+        [string]$WriteToken,
+
+        [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true)]
         [string]$Proxy,
 
         [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true)]
@@ -73,6 +79,7 @@ function Set-CIF3Config {
             'Uri' { $Script:CIF3.Uri = $Uri }
             'Token' { $Script:CIF3.Token = $Token }
             'ReadToken' { $Script:CIF3.ReadToken = $ReadToken }
+            'WriteToken' { $Script:CIF3.WriteToken = $WriteToken }
             'Proxy' { $Script:CIF3.Proxy = $Proxy }
             'ForceVerbose' { $Script:CIF3.ForceVerbose = $ForceVerbose }
             'NoVerifySsl' { $Script:CIF3.NoVerifySsl = $NoVerifySsl }
@@ -94,6 +101,7 @@ function Set-CIF3Config {
                 "remote"        = "$($Script:CIF3.Uri)"
                 "token"         = "$(Encrypt $Script:CIF3.Token)"
                 "read_token"    = "$(Encrypt $Script:CIF3.ReadToken)"
+                "write_token"   = "$(Encrypt $Script:CIF3.WriteToken)"
                 "no_verify_ssl" = "$($Script:CIF3.NoVerifySsl)"
                 "force_verbose" = "$($Script:CIF3.ForceVerbose)"
                 "proxy"         = "$($Script:CIF3.Proxy)"

--- a/Public/Test-CIF3Auth.ps1
+++ b/Public/Test-CIF3Auth.ps1
@@ -44,9 +44,11 @@ function Test-CIF3Auth {
     begin {
         if ($VerifyWrite -eq $true) {
             $Uri += '/ping?write=1'
+            $Token = Select-ClientToken -Token $Token -RequestType 'Write'
         }
         else {
             $Uri += '/ping'
+            $Token = Select-ClientToken -Token $Token -RequestType 'Read'
         }
     }
 


### PR DESCRIPTION
- Added a `write_token` option to the client config yml file.
- Added `WriteToken` parameter to Set-CIF3Config function
- Add-CIF3Indicator will now attempt to use the write token if one exists and if a explicit parameter is not passed to the function.