### PR TITLE
feature/find relatives

### DIFF
--- a/CIF3.psd1
+++ b/CIF3.psd1
@@ -9,7 +9,7 @@
     RootModule        = 'CIF3.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '0.9.9'
+    ModuleVersion     = '1.0.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()
@@ -105,7 +105,7 @@
             # IconUri = ''
 
             # ReleaseNotes of this module
-            ReleaseNotes = 'Fixes potential timezone issue with StartTime and EndTime params.'
+            ReleaseNotes = 'Adds new params to Get-CIF3Indicator cmdlet.'
 
         } # End of PSData hashtable
 

--- a/Private/Send-CIF3Api.ps1
+++ b/Private/Send-CIF3Api.ps1
@@ -104,7 +104,7 @@ function Send-CIF3Api {
         try {
             $Response = $null
             # https://stackoverflow.com/a/30415506
-            $ExpandedHash = $Params | Format-Table Name, @{n='Value';e={
+            $ExpandedHash = $Body | Format-Table Name, @{n='Value';e={
                 if ($_.Value -is [hashtable]) {
                   $ht = $_.Value
                   $a = $ht.Keys | ForEach-Object { if ($ht[$_] -ne '') { '{0}={1}' -f $_, $ht[$_] } }

--- a/Public/Get-CIF3Feed.ps1
+++ b/Public/Get-CIF3Feed.ps1
@@ -133,7 +133,7 @@ function Get-CIF3Feed {
             'ResultSize'        { $Body.Add('limit', $ResultSize) }
             'IType'             { $Body.Add('itype', $IType) }
             'ExtraParams'       { foreach ($Param in $ExtraParams.GetEnumerator()) {
-                                  $Body.Add($Param.Key, $Param.Value)
+                                  $Body.Add($Param.Key.ToLower(), $Param.Value)
                 } 
             }
         }

--- a/Public/Get-CIF3Feed.ps1
+++ b/Public/Get-CIF3Feed.ps1
@@ -21,7 +21,7 @@ function Get-CIF3Feed {
         # Return feed of high-confidence md5 hashes tagged as 'malware,' 
         # and include additional param in API call which will be added to URL parameter as "?testKey=testValue"
         # This enables passing URL parameters supported by the REST API that may not have explicit params supported by this module.
-        PS C:\> Get-CIF3Feed -Confidence 8 -Tag malware -IType md5 -ExtraParams @{ 'testKey' = 'testValue' }
+        PS C:\> Get-CIF3Feed -Confidence 8 -Tag malware -IType md5 -ExtraParams @{ 'tlp' = 'green' }
 
     .OUTPUTS
         A an array of PSCustomObjects from CIF instance's API composed of indicator properties.

--- a/Public/Get-CIF3Indicator.ps1
+++ b/Public/Get-CIF3Indicator.ps1
@@ -151,7 +151,7 @@ function Get-CIF3Indicator {
             'IType'             { $Body.Add('itype', $IType) }
             'IncludeRelatives'  { $Body.Add('find_relatives', $IncludeRelatives) }
             'ExtraParams'       { foreach ($Param in $ExtraParams.GetEnumerator()) {
-                                  $Body.Add($Param.Key, $Param.Value)
+                                  $Body.Add($Param.Key.ToLower(), $Param.Value)
                 } 
             }
         }

--- a/Public/Get-CIF3Indicator.ps1
+++ b/Public/Get-CIF3Indicator.ps1
@@ -64,6 +64,7 @@ function Get-CIF3Indicator {
         parent/child CIDRs for IPs.
     .PARAMETER Sort
         Backend fields by which to sort server-side before returning results.
+        Defaults to '-reporttime', '-lasttime' which primary sorts reporttime DESC and secondary sorts lasttime DESC.
     .PARAMETER ExtraParams
         Additional, optional URL params for which there is not a defined cmdlet param that will be passed to CIF's API.
     .PARAMETER Raw

--- a/Public/Get-CIF3Indicator.ps1
+++ b/Public/Get-CIF3Indicator.ps1
@@ -27,7 +27,7 @@ function Get-CIF3Indicator {
         # Return any results for specified indicator, and include additional param in API call which
         # will be added to URL parameter as "?testKey=testValue"
         # This enables passing URL parameters supported by the REST API that may not have explicit params supported by this module.
-        PS C:\> Get-CIF3Indicator -Indicator 'bad.tld' -ExtraParams @{ 'testKey' = 'testValue' }
+        PS C:\> Get-CIF3Indicator -Indicator 'bad.tld' -ExtraParams @{ 'tlp' = 'green' }
 
     .OUTPUTS
         A an array of PSCustomObjects from CIF instance's API composed of indicator properties.

--- a/README.md
+++ b/README.md
@@ -114,14 +114,27 @@ Add an indicator for 'baddomain.xyz' at a confidence of 7, a yellow TLP, and tag
 Add-CIF3Indicator -Indicator baddomain.xyz -Confidence 7 -Tag malware -TLP yellow
 ```
 
+Search for the indicator `44.227.178.5` and include any matching parent CIDRs that are known. Results are sorted by confidence highest to lowest, with any equal-confidence indicators being further sorted by reporttime oldest to newest before being returned:
+
+```powershell
+Get-CIF3Indicator -Indicator '44.227.178.5' -IncludeRelatives -Sort '-confidence', 'reporttime'
+```
+
 ### Feeds
 
-Feeds are aggregated and filtered datasets that have had whitelists applied before being returned. Indicator type is the only mandatory parameter when generating a feed.
+Feeds are aggregated, deduplicated, and filtered datasets that have had allowlists applied before being returned. Indicator type is the only mandatory parameter when generating a feed.
 
 Get a feed of all fqdn indicators with a confidence of 7.5 or greater:
 
 ```powershell
 Get-CIF3Feed -IType fqdn -Confidence 7.5
+```
+
+Get a feed of all md5 indicators with a confidence of 9 or greater tagged as 'malware.' 
+Additionally, add the `?apiParam=paramValue` string to the final REST request:
+
+```powershell
+Get-CIF3Feed -IType md5 -Confidence 9 -Tag 'malware' -ExtraParams @{ 'apiParam' = 'paramValue' }
 ```
 
 # Acknowledgments


### PR DESCRIPTION
* Adds params `-ExtraParams` and `-IncludeRelatives`
  * `-IncludeRelatives` will find parent/child CIDRs or IPs if one is given for search criteria
  * `-ExtraParams` allows one to specify additional API params for which there isn't an explicit pwsh param
* Adds new itype `ssdeep`